### PR TITLE
Default Embed Function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__/
 build
 *.egg-info
+.venv

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
+dev:
+	pip install -e ".[dev]"
+	python3 ./validator/post-install.py
+
 lint:
 	ruff check .
 
-tests:
-	pytest ./test
+test:
+	pytest ./tests
 
 type:
 	pyright validator
@@ -10,4 +14,4 @@ type:
 qa:
 	make lint
 	make type
-	make tests
+	make test

--- a/README.md
+++ b/README.md
@@ -144,6 +144,6 @@ Note:
     | Key | Type | Description | Default |
     | --- | --- | --- | --- |
     | `prev_vals` | _list_ | List of previous values to pass to the validator | N/A |
-    | `embed_function` | _Callable_ | Function to embed the input text | N/A |
+    | `embed_function` | _Callable_ | Function to embed the input text | sentence-transformer's `paraphrase-MiniLM-L6-v2` |
 
 </ul>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,14 +10,17 @@ readme = "README.md"
 requires-python = ">= 3.8.1"
 dependencies = [
     "guardrails-ai>=0.4.0",
-    "numpy"
+    "numpy",
+    "sentence-transformers"
 ]
 
 [project.optional-dependencies]
 dev = [
     "pyright",
     "pytest",
-    "ruff"
+    "ruff",
+    "cohere"
+
 ]
 
 [tool.pytest.ini_options]

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -9,7 +9,7 @@ import cohere
 from validator import SimilarToPreviousValues
 
 # Create a cohere client
-cohere_key = os.environ["COHERE_API_KEY"]
+cohere_key = os.environ.get("COHERE_API_KEY")
 cohere_client = cohere.Client(api_key=cohere_key)
 
 def embed_function(text: Union[str, List[str]]) -> np.ndarray:
@@ -28,7 +28,7 @@ def embed_function(text: Union[str, List[str]]) -> np.ndarray:
 
 # Create a pydantic model with a field that uses the custom validator
 class ValidatorTestObject(BaseModel):
-    text: str = Field(validators=[SimilarToPreviousValues(threshold=0.7, on_fail="exception")])
+    text: str = Field(validators=[SimilarToPreviousValues(threshold=0.65, on_fail="exception")])
 
 
 # Test happy path
@@ -44,6 +44,16 @@ class ValidatorTestObject(BaseModel):
             {
                 "prev_values": ["You are amazing", "You are awesome.", "You are great!"],
                 "embed_function": embed_function
+            }
+        ),
+        (
+            """
+            {
+                "text": "You are phenomenal!"
+            }
+            """,
+            {
+                "prev_values": ["You are amazing", "You are awesome.", "You are great!"],
             }
         )
     ],
@@ -78,9 +88,7 @@ def test_happy_path(value, metadata):
                 "text": "You are so good at this!"
             }
             """,
-            {
-                "prev_values": ["I love you.", "You are awesome.", "You are great!"],
-            }  # Missing embed_function
+            {}  # Missing prev_values
         ),
     ],
 )

--- a/validator/main.py
+++ b/validator/main.py
@@ -9,6 +9,7 @@ from guardrails.validator_base import (
 )
 
 import numpy as np
+from sentence_transformers import SentenceTransformer
 
 @register_validator(name="guardrails/similar_to_previous_values", data_type=["string", "integer", "float"])
 class SimilarToPreviousValues(Validator):
@@ -124,10 +125,12 @@ class SimilarToPreviousValues(Validator):
             # Check embed function
             embed_function = metadata.get("embed_function", None)
             if embed_function is None:
-                raise ValueError(
-                    "You must provide `embed_function` in metadata in order to "
-                    "check the semantic similarity of the generated string."
-                )
+                # Load model for embedding function
+                MODEL = SentenceTransformer("paraphrase-MiniLM-L6-v2")
+                # Create embed function
+                def st_embed_function(sources: list[str]):
+                    return MODEL.encode(sources)
+                embed_function = st_embed_function
 
             # Check whether the value is semantically similar to the prev_values
             # Get average semantic similarity

--- a/validator/post-install.py
+++ b/validator/post-install.py
@@ -1,0 +1,4 @@
+from sentence_transformers import SentenceTransformer
+
+# Load model for default embedding function
+SentenceTransformer("paraphrase-MiniLM-L6-v2")


### PR DESCRIPTION
This PR adds a default `embed_function` that can be used when one is not passed by the user in the metadata.  This both lowers barrier to entry for using this validators, and other like it, as well as enables easier integration into the Hub playground.

Related to https://github.com/guardrails-ai/validator-hub-ui/pull/9